### PR TITLE
Add CSV export from page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # Bikes-upload
+
+This repository includes a simple Chrome Extension named **Bike Catalog Assistant**. The extension helps extract data from the bike upload page and export it as CSV.
+
+## Loading the extension
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select the `extension` folder in this repository.
+
+## Usage
+
+1. Visit the bike upload page in your backoffice.
+2. A side panel titled **Bike Assistant** will appear.
+3. Click **Generate CSV** to collect the current page values. The result is
+   displayed in the panel and can be downloaded using **Download CSV**.
+
+The exported file follows the format `field, certainty, suggestion, source, details`. Values are read from the page with a certainty of `100` and the source marked as `page`.

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,105 @@
+(function() {
+  // Utility to create the side panel
+  function createPanel() {
+    let panel = document.getElementById('bike-assistant-panel');
+    if (panel) return panel;
+    panel = document.createElement('div');
+    panel.id = 'bike-assistant-panel';
+    panel.style.position = 'fixed';
+    panel.style.top = '0';
+    panel.style.right = '0';
+    panel.style.width = '400px';
+    panel.style.height = '100%';
+    panel.style.background = 'white';
+    panel.style.borderLeft = '1px solid #ccc';
+    panel.style.zIndex = 9999;
+    panel.style.overflowY = 'auto';
+    panel.style.fontSize = '14px';
+    panel.style.fontFamily = 'sans-serif';
+    document.body.appendChild(panel);
+    panel.innerHTML =
+      '<h2 style="padding:10px">Bike Assistant</h2>' +
+      '<button id="bike-assistant-fetch" style="margin:10px">Generate CSV</button>' +
+      '<button id="bike-assistant-download" style="margin:10px">Download CSV</button>' +
+      '<div style="padding:10px">' +
+      '<pre id="bike-assistant-csv" style="white-space:pre-wrap;border:1px solid #ccc;padding:5px"></pre>' +
+      '</div>';
+    return panel;
+  }
+
+  // Gather data from the page
+  function collectData() {
+    const fields = {
+      bikeId: (location.search.match(/bikeId=([^&#]+)/) || [,''])[1] ||
+               (document.querySelector('img[src*="/bikes/"]') || {}).src?.match(/bikes\/(\w+)-/)?.[1] || '' ,
+      brand: document.getElementById('input-brand')?.value || '',
+      model: document.getElementById('input-model')?.value || '',
+      color: document.getElementById('headlessui-combobox-input-:ra:')?.value || '',
+      category: Array.from(document.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.nextElementSibling?.textContent?.trim()).join(', '),
+      frameType: document.getElementById('input-frameType')?.value || '',
+      rackPosition: document.getElementById('input-rackPosition')?.value || '',
+      rearRackMaxLoad: document.getElementById('input-Rear rack max load')?.value || '',
+      year: document.getElementById('input-year')?.value || '',
+      seatTube: document.getElementById('input-seatTube')?.value || '',
+      size: document.getElementById('input-size')?.value || '',
+      minSize: document.getElementById('input-minSize')?.value || '',
+      maxSize: document.getElementById('input-maxSize')?.value || '',
+      brakes: document.getElementById('headlessui-combobox-input-:r16:')?.value || '',
+      tyreBrand: document.getElementById('input-tyreBrand')?.value || '',
+      etrto: document.getElementById('input-etrto')?.value || '',
+      wheelsSize: document.getElementById('input-wheelsSize')?.value || '',
+      transmissionBrand: document.getElementById('input-transmissionBrand')?.value || '',
+      transmissionModel: document.getElementById('input-transmissionModel')?.value || '',
+      transmissionSpeed: document.getElementById('input-transmissionSpeed')?.value || '',
+      transmissionSystem: document.getElementById('input-transmissionSystem')?.value || '',
+      drivetrain: document.getElementById('input-drivetrain')?.value || '',
+      mileage: document.getElementById('input-mileage')?.value || '',
+      engineBrand: document.getElementById('input-engineBrand')?.value || '',
+      engineModel: document.getElementById('input-engineModel')?.value || '',
+      engineLocation: document.getElementById('input-engineLocation')?.value || '',
+      completedCycles: document.getElementById('input-completedCycles')?.value || '',
+      boschDisplayModel: document.getElementById('headlessui-combobox-input-:ro8:')?.value || '',
+      boschRemoteModel: document.getElementById('headlessui-combobox-input-:roc:')?.value || '',
+      batteryCapacityWh: document.getElementById('input-batteryCapacity (Wh)')?.value || '',
+      batteryVolts: document.getElementById('input-batteryVolts')?.value || '',
+      batteryLocation: document.getElementById('input-batteryLocation')?.value || '',
+      batteryRemovability: document.getElementById('headlessui-combobox-input-:r2t:')?.value || ''
+    };
+    const photos = Array.from(document.querySelectorAll('a[href*="/bikes/"]')).map(a => a.href);
+    return { fields, photos };
+  }
+
+  function buildInputCSV(data) {
+    const lines = [];
+    Object.entries(data.fields).forEach(([k, v]) => {
+      lines.push(`${k},100,${v},page,`);
+    });
+    data.photos.forEach((p, idx) => {
+      lines.push(`photo${idx + 1},100,${p},page,`);
+    });
+    return lines.join('\n');
+  }
+
+
+  function downloadCSV(text) {
+    const blob = new Blob([text], {type: 'text/csv'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'bike.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+
+  const panel = createPanel();
+  document.getElementById('bike-assistant-fetch').addEventListener('click', () => {
+    const data = collectData();
+    const csv = buildInputCSV(data);
+    document.getElementById('bike-assistant-csv').textContent = csv;
+    panel.dataset.csv = csv;
+  });
+  document.getElementById('bike-assistant-download').addEventListener('click', () => {
+    if (panel.dataset.csv) downloadCSV(panel.dataset.csv);
+  });
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Bike Catalog Assistant",
+  "version": "0.1",
+  "description": "Assist with bike cataloging by extracting page info and exporting it as CSV.",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "Bike Assistant"
+  }
+}


### PR DESCRIPTION
## Summary
- simplify extension to only gather values from the bike upload page
- generate a CSV with columns `field, certainty, suggestion, source, details`
- allow download of the generated CSV
- document new workflow in the README

## Testing
- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync("extension/manifest.json","utf8")); console.log("manifest OK")'`

------
https://chatgpt.com/codex/tasks/task_e_6845c61f2fbc8320aec12d33680aa50c